### PR TITLE
Add license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+The Otterscan Book © 2024 by Otterscan contributors is licensed under CC BY 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/

--- a/src/license.md
+++ b/src/license.md
@@ -3,3 +3,5 @@
 Otterscan is distributed under the MIT License and redistributes MIT-compatible dependencies.
 
 The Otterscan API is implemented inside Erigon and follows its own license (LPGL-3).
+
+The Otterscan Book (this documentation) is distributed under CC BY 4.0.


### PR DESCRIPTION
We are going to license this documentation under CC BY 4.0, which seems to be a more appropriate license for documentation than MIT, for example, and it is very similar.

just for reference, it is the same license used by ethers.js docs.