### PR TITLE
Add trace namespace suggestion to install instructions

### DIFF
--- a/src/install/erigon.md
+++ b/src/install/erigon.md
@@ -2,14 +2,14 @@
 
 ## Enable the Otterscan RPC namespace in Erigon
 
-When running Erigon, make sure to enable the `eth`, `erigon` and `ots` namespaces in addition to whatever CLI options you are using to start Erigon.
+When running Erigon, make sure to enable the `eth`, `erigon`, `trace` and `ots` namespaces in addition to whatever CLI options you are using to start Erigon. The `trace` namespace is used for transaction state diffs.
 
 Enabling namespaces in Erigon is done through the `--http.api` argument.
 
 ### Example
 
 ```sh
-erigon --http.api "eth,erigon,ots[,<other-namespaces>]" [<other CLI arguments...>]
+erigon --http.api "eth,erigon,trace,ots[,<other-namespaces>]" [<other CLI arguments...>]
 ```
 
 > `ots` stands for Otterscan, and it is the JSON-RPC namespace we use for our own custom APIs.

--- a/src/install/ots2.md
+++ b/src/install/ots2.md
@@ -25,7 +25,7 @@ For example, if your Erigon start command is:
 
 ```sh
 erigon \
-        --http.api "eth,erigon,ots" \
+        --http.api "eth,erigon,trace,ots" \
         [<other CLI arguments>]
 ```
 
@@ -33,7 +33,7 @@ change it to:
 
 ```sh
 erigon \
-        --http.api "eth,erigon,ots,ots2" \
+        --http.api "eth,erigon,trace,ots,ots2" \
         --experimental.ots2 \
         [<other CLI arguments>]
 ```


### PR DESCRIPTION
The state diff uses the `trace` namespace. Our revert reason source lookup will for now require them too.