### PR TITLE
Update Sourcify sources docs with new `sources` format

### DIFF
--- a/src/config/options/sourcify.md
+++ b/src/config/options/sourcify.md
@@ -1,22 +1,31 @@
 # Alternative Sourcify sources
 
-Rather than using the default `ipfs.io` and `repo.sourcify.dev` sites for accessing Sourcify, you may specify your own Sourcify root URLs in the configuration file by adding the `sourcify` key and changing the `sources` URLs accordingly:
+Otterscan uses smart contract metadata to decode function parameters, name smart contract addresses, and show sources. By default, this data comes from the official Sourcify servers. We encourage you to [self-host this Sourcify data](../../contract-verification/lightweight-sourcify-server.md) to prevent your browsing activity from being leaked to Sourcify, to increase the loading speed of this data, to ensure continued availability of the data, and to reduce the load on Sourcify servers.
+
+Rather than using `repo.sourcify.dev`, you may specify your own Sourcify root URLs in the configuration file by adding the `sourcify` key and adding objects to `sources`:
 
 ```json
 "sourcify": {
   "sources": {
-    "ipfs": "https://ipfs.io/ipns/repo.sourcify.dev",
-    "central_server": "https://repo.sourcify.dev"
-  },
-  "backendFormat": "RepositoryV1"
+    "Local Repository": {
+      "url": "http://localhost:7077",
+      "backendFormat": "RepositoryV2"
+    },
+    "Sourcify Servers": {
+      "url": "https://repo.sourcify.dev",
+      "backendFormat": "RepositoryV1"
+    }
+  }
 }
 ```
+
+The first listed Sourcify source will be the default.
 
 This is useful if you have your own Sourcify repository hosted locally, in which case all of your Otterscan activity will be private. See our section on hosting a [lightweight self-hosted repo](../../contract-verification/lightweight-sourcify-server.md) to download and host a current snapshot of all Sourcify's contracts locally.
 
 The `backendFormat` key current accepts two options:
 
 * `RepositoryV1`
-  * All sources are saved to `/<chainID>/<address>/sources/<source path>`.
+  * All sources are accessible from `/<chainID>/<address>/sources/<source path>`.
 * `RepositoryV2`
-  * All sources are saved to `/<chainID>/<address>/sources/<keccak256(source path)>`.
+  * All sources are accessible from `/<chainID>/<address>/sources/<keccak256(source path)>`.

--- a/src/config/options/sourcify.md
+++ b/src/config/options/sourcify.md
@@ -1,6 +1,6 @@
 # Alternative Sourcify sources
 
-Otterscan uses smart contract metadata to decode function parameters, name smart contract addresses, and show sources. By default, this data comes from the official Sourcify servers. We encourage you to [self-host this Sourcify data](../../contract-verification/lightweight-sourcify-server.md) to prevent your browsing activity from being leaked to Sourcify, to increase the loading speed of this data, to ensure continued availability of the data, and to reduce the load on Sourcify servers.
+Otterscan uses smart contract metadata to decode function parameters, name smart contract addresses, and show sources. By default, this data comes from the official Sourcify servers. We encourage you to [self-host this Sourcify data](../../contract-verification/lightweight-sourcify-server.md) to prevent your browsing activity from being leaked to Sourcify, increase the loading speed of this data, ensure continued availability of the data, and reduce the load on Sourcify servers.
 
 Rather than using `repo.sourcify.dev`, you may specify your own Sourcify root URLs in the configuration file by adding the `sourcify` key and adding objects to `sources`:
 

--- a/src/config/reading/devel.md
+++ b/src/config/reading/devel.md
@@ -24,10 +24,11 @@ VITE_CONFIG_JSON='
   },
   "sourcify": {
     "sources": {
-      "ipfs": "https://ipfs.io/ipns/repo.sourcify.dev",
-      "central_server": "https://repo.sourcify.dev"
-    },
-    "backendFormat": "RepositoryV1"
+      "Sourcify Servers": {
+        "url": "https://repo.sourcify.dev",
+        "backendFormat": "RepositoryV1"
+      }
+    }
   }
 }
 '

--- a/src/contract-verification/lightweight-sourcify-server.md
+++ b/src/contract-verification/lightweight-sourcify-server.md
@@ -42,15 +42,20 @@ You can host the extracted repository using Caddy, a lightweight, portable HTTP(
      
      </details>
 
-3. Update the Otterscan config. Your Sourcify repository is now hosted at `http://localhost:7877`. Update your Otterscan config to point to your new repository URL:
+3. Update the Otterscan config. Your Sourcify repository is now hosted at `http://localhost:7877`. Add an entry in your Otterscan config to point to your new repository URL:
 
    ```json
    "sourcify": {
      "sources": {
-       "ipfs": "http://localhost:7877",
-       "central_server": "http://localhost:7877"
-     },
-     "backendFormat": "RepositoryV2"
+       "Local Sourcify Repo": {
+         "url": "http://localhost:7877",
+         "backendFormat": "RepositoryV2"
+       },
+       "Sourcify Servers": {
+         "url": "https://repo.sourcify.dev",
+         "backendFormat": "RepositoryV1"
+       }
+     }
    }
    ```
 

--- a/src/contract-verification/self-hosted-sourcify/setup.md
+++ b/src/contract-verification/self-hosted-sourcify/setup.md
@@ -79,9 +79,14 @@ In your Otterscan configuration JSON, specify your local Sourcify repository as 
 ```json
 "sourcify": {
   "sources": {
-    "ipfs": "http://localhost:5555/repository",
-    "central_server": "http://localhost:5555/repository"
-  },
-  "backendFormat": "RepositoryV1"
+    "Local Sourcify Repo": {
+      "url": "http://localhost:5555/repository",
+      "backendFormat": "RepositoryV2"
+    },
+    "Sourcify Servers": {
+      "url": "https://repo.sourcify.dev",
+      "backendFormat": "RepositoryV1"
+    }
+  }
 }
 ```


### PR DESCRIPTION
Updates the documentation to reflect the new Sourcify sources format.

I think given the changes we have made, it is sufficient to do this:
Closes #21 